### PR TITLE
Add React 16 to peerDependency version range.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "prop-types": "^15.5.7"
   },
   "peerDependencies": {
-    "react": "^15.5.0"
+    "react": "^15.5.0 || ^16"
   }
 }


### PR DESCRIPTION
I've been using it with React 16 and haven't had any problems. Just bumping the version range to get rid of the peerDependency warning.