### PR TITLE
onPress, onPressHighlighted and PropType fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,19 @@
 import React from 'react';
-import {Text} from 'react-native';
-import {findAll} from 'highlight-words-core';
-import PropTypes from 'prop-types';
+import { Text } from 'react-native';
+import { findAll } from 'highlight-words-core';
+import PropTypes, { oneOfType } from 'prop-types';
 
 Highlighter.propTypes = {
     autoEscape: PropTypes.bool,
     highlightStyle: Text.propTypes.style,
-    searchWords: PropTypes.arrayOf(PropTypes.string).isRequired,
+    searchWords: oneOfType([
+        PropTypes.arrayOf(PropTypes.string),
+        PropTypes.arrayOf(PropTypes.instanceOf(RegExp))]).isRequired,
     textToHighlight: PropTypes.string.isRequired,
     sanitize: PropTypes.func,
-    style: Text.propTypes.style
+    style: Text.propTypes.style,
+    onPress: PropTypes.func,
+    onPressHighlighted: PropTypes.func,
 };
 
 /**
@@ -22,13 +26,15 @@ export default function Highlighter({
     searchWords,
     textToHighlight,
     sanitize,
+    onPress,
+    onPressHighlighted,
     style,
     ...props
 }) {
-    const chunks = findAll({textToHighlight, searchWords, sanitize, autoEscape});
+    const chunks = findAll({ textToHighlight, searchWords, sanitize, autoEscape });
 
     return (
-        <Text style={style} {...props}>
+        <Text style={style} {...props} onPress={onPress}>
             {chunks.map((chunk, index) => {
                 const text = textToHighlight.substr(chunk.start, chunk.end - chunk.start);
 
@@ -36,6 +42,7 @@ export default function Highlighter({
                     ? text
                     : (
                         <Text
+                            onPress={() => onPressHighlighted({text})}
                             key={index}
                             style={chunk.highlight && highlightStyle}
                         >


### PR DESCRIPTION
Even though RegExp is supported and works with current version, it was warning as "Not Valid Type". 
Also `onPress` events were crucial requirements.

* Added `instanceOf` correction for regexp type.

* Added `onPress` and `onPressHighlighted` functions

> onPress includes whole text
> onPressHighlighted({ text: string }})